### PR TITLE
Command line arguments for encoders and channels

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,24 +3,24 @@
 # OR  Take and process command line args -> use transmit module's retrieve method to grab data -> write out data
 
 # command line arguments:
-# you can input multiple transfer arguments, so -transfer and encoder will give a 
+# you can input multiple transfer arguments, so -transfer and encoder will give a
 # list of arguments. Need to change use encoder and use channel to loop
 import argparse
 parser = argparse.ArgumentParser(description = 'Use social media as a tool\
-								 for data exfiltration.', epilog = "Aw yee.")
+                                 for data exfiltration.', epilog = "Aw yee.")
 parser.add_argument('-transfer', '-t', dest = 'channelName', action = 'append',
-							 help = 'Choose location to transfer to \
-							 (e.g, -transfer twitter). Channels that are supported:\
-							  twitter (not really yet)', required = False) #change to True when done
+                             help = 'Choose location to transfer to \
+                             (e.g, -transfer twitter). Channels that are supported:\
+                              twitter (not really yet)', required = False) #change to True when done
 parser.add_argument('-encode', '-e', dest = 'encoderName', action = 'append',
-							 help = 'Choose methods of encoding (done in order given).\
-							  Current methods: none :-(', required = False) #change to True when done
+                             help = 'Choose methods of encoding (done in order given).\
+                              Current methods: none :-(', required = False) #change to True when done
 args = parser.parse_args()
 d =  vars(args)
 if d.get('channelName', -1) != -1: #if arguement is put in
-	channelName = d['channelName']
+    channelName = d['channelName']
 if d.get('encoderName', -1) != -1:
-	encoderName = d['encoderName']
+    encoderName = d['encoderName']
 
 print channelName, encoderName
 

--- a/main.py
+++ b/main.py
@@ -2,6 +2,27 @@
 # Take and process command line args -> read in data -> encode data (potentially multiple times) -> transmit data
 # OR  Take and process command line args -> use transmit module's retrieve method to grab data -> write out data
 
+# command line arguments:
+# you can input multiple transfer arguments, so -transfer and encoder will give a 
+# list of arguments. Need to change use encoder and use channel to loop
+import argparse
+parser = argparse.ArgumentParser(description = 'Use social media as a tool\
+								 for data exfiltration.', epilog = "Aw yee.")
+parser.add_argument('-transfer', '-t', dest = 'channelName', action = 'append',
+							 help = 'Choose location to transfer to \
+							 (e.g, -transfer twitter). Channels that are supported:\
+							  twitter (not really yet)', required = False) #change to True when done
+parser.add_argument('-encode', '-e', dest = 'encoderName', action = 'append',
+							 help = 'Choose methods of encoding (done in order given).\
+							  Current methods: none :-(', required = False) #change to True when done
+args = parser.parse_args()
+d =  vars(args)
+if d.get('channelName', -1) != -1: #if arguement is put in
+	channelName = d['channelName']
+if d.get('encoderName', -1) != -1:
+	encoderName = d['encoderName']
+
+print channelName, encoderName
 
 # to use an encoder:
 import importlib

--- a/main.py
+++ b/main.py
@@ -2,27 +2,31 @@
 # Take and process command line args -> read in data -> encode data (potentially multiple times) -> transmit data
 # OR  Take and process command line args -> use transmit module's retrieve method to grab data -> write out data
 
+# get list of available modules
+# TODO make this detect modules instaed of being manual
+channelOptions = ['twitter']
+encodingOptions = ['base64']
+
 # command line arguments:
 # you can input multiple transfer arguments, so -transfer and encoder will give a
 # list of arguments. Need to change use encoder and use channel to loop
 import argparse
 parser = argparse.ArgumentParser(description = 'Use social media as a tool\
-                                 for data exfiltration.', epilog = "Aw yee.")
-parser.add_argument('-transfer', '-t', dest = 'channelName', action = 'append',
-                             help = 'Choose location to transfer to \
-                             (e.g, -transfer twitter). Channels that are supported:\
-                              twitter (not really yet)', required = False) #change to True when done
-parser.add_argument('-encode', '-e', dest = 'encoderName', action = 'append',
-                             help = 'Choose methods of encoding (done in order given).\
-                              Current methods: none :-(', required = False) #change to True when done
+                                 for data exfiltration.')
+parser.add_argument('--channel', '-c', dest = 'channelName', metavar="channel_name", action = 'store',
+                             help = 'Choose a channel to transfer data over \
+                             (e.g, --transfer twitter). Channels available: '+\
+                             ", ".join(channelOptions), required = False) #change to True when done
+parser.add_argument('--encode', '-e', dest = 'encoderNames', metavar="encoder_name", nargs='+', action = 'store',
+                             help = 'Choose one or more methods of encoding (done in order given).\
+                             Encoders available: ' + ", ".join(encodingOptions), required = False) #change to True when done
+
 args = parser.parse_args()
 d =  vars(args)
-if d.get('channelName', -1) != -1: #if arguement is put in
-    channelName = d['channelName']
-if d.get('encoderName', -1) != -1:
-    encoderName = d['encoderName']
+channelName = d.get('channelName')
+encoderNames = d.get('encoderNames')
 
-print channelName, encoderName
+print channelName, encoderNames
 
 # to use an encoder:
 import importlib

--- a/main.py
+++ b/main.py
@@ -4,50 +4,52 @@
 
 # get list of available modules
 # TODO make this detect modules instaed of being manual
-channelOptions = ['twitter']
-encodingOptions = ['base64']
+channelOptions = ['twitter', 'exampleChannel']
+encodingOptions = ['base64', 'exampleEncoder']
 
 # command line arguments:
 # you can input multiple transfer arguments, so -transfer and encoder will give a
 # list of arguments. Need to change use encoder and use channel to loop
 import argparse
-parser = argparse.ArgumentParser(description = 'Use social media as a tool\
-                                 for data exfiltration.')
+parser = argparse.ArgumentParser(description = 'Use social media as a tool for data exfiltration.')
 parser.add_argument('--channel', '-c', dest = 'channelName', metavar="channel_name", action = 'store',
                              help = 'Choose a channel to transfer data over \
                              (e.g, --transfer twitter). Channels available: '+\
-                             ", ".join(channelOptions), required = False) #change to True when done
+                             ", ".join(channelOptions), required = True)
 parser.add_argument('--encode', '-e', dest = 'encoderNames', metavar="encoder_name", nargs='+', action = 'store',
                              help = 'Choose one or more methods of encoding (done in order given).\
-                             Encoders available: ' + ", ".join(encodingOptions), required = False) #change to True when done
+                             Encoders available: ' + ", ".join(encodingOptions), required = True)
 
 args = parser.parse_args()
 d =  vars(args)
 channelName = d.get('channelName')
 encoderNames = d.get('encoderNames')
 
-print channelName, encoderNames
+print("")
+print("Pipeline: " + "-> ".join(encoderNames) + "-> " + channelName)
+print("")
 
-# to use an encoder:
 import importlib
-encoderName = 'exampleEncoder'
-moduleName = '.'.join(['encoders', encoderName])
-enc = importlib.import_module(moduleName)
-# This is a programmatic equivalent of:
-# from encoding import exampleEncoder as enc
 
-ret = enc.encode('this is my data')
-print(ret)
+# TODO read in data from stdin or a file
+data = 'this is my data'
+for encoderName in encoderNames:
+    moduleName = '.'.join(['encoders', encoderName])
+    enc = importlib.import_module(moduleName)
+    # This is a programmatic equivalent of:
+    # from encoding import exampleEncoder as enc
 
+    data = enc.encode(data)
+
+print(data)
 
 # to use a channel:
-channelName = 'exampleChannel'
 moduleName = '.'.join(['channels', channelName])
 chan = importlib.import_module(moduleName)
 
 # send some stuff
-chan.send("some data")
+chan.send(data)
 
 # receive some stuff
-ret = chan.receive()
-print(ret)
+resp = chan.receive()
+print(resp)


### PR DESCRIPTION
Allows (requires, actually) setting encoders and channels to be used, then runs some fake data through each encoder and then the channel in turn.
