### PR TITLE
File channel

### DIFF
--- a/channels/file.py
+++ b/channels/file.py
@@ -1,0 +1,28 @@
+'''
+This channel writes the resultant data out to a file, or reads in from a file to receive.
+
+Useful for testing, and also out of band transfer.
+'''
+
+requiredParams = {
+    'sending': {
+        'filename': 'Name of the file to write data to.'
+               },
+    'receiving': {
+        'filename': 'Name of the file to read data from.'
+                 }
+    }
+
+def send(data, params):
+    print("Writing data to " + params['filename'] + "...")
+    with open(params['filename'] , 'w') as f:
+        f.write(data)
+    print("Done.")
+    return
+
+def receive(params):
+    print("Reading data from " + params['filename'] + "...")
+    with open(params['filename'], 'rb') as f:
+        data = f.read()
+    print("Done.")
+    return [data]

--- a/encoders/identity.py
+++ b/encoders/identity.py
@@ -1,0 +1,17 @@
+'''
+An encoder that does no encoding. Ironic, but also useful for testing channels.
+Or not encoding/decoding.
+'''
+
+requiredParams = {
+    'encode': {},
+    'decode': {}
+}
+
+
+def encode(data, params=None):
+    return data
+
+
+def decode(data, params=None):
+    return data

--- a/main.py
+++ b/main.py
@@ -62,6 +62,19 @@ parser_receive.add_argument('--encoder', '-e', dest = 'encoderNames', metavar="e
 parser_receive.add_argument('--parameters', '-p', dest = 'params', metavar="parameter_name", nargs='+', action = 'append',
                              help = 'Specify parameters as name-value pairs [-p name value] to be passed to encoder and channel modules.')
 
+
+# subparser for echoing data
+parser_echo = subparsers.add_parser('echo')
+
+parser_echo.add_argument('--encoder', '-e', dest = 'encoderNames', metavar="encoder_name", nargs='+', action = 'store',
+                             help = 'Choose one or more methods of encoding (done in order given).', required=True)
+
+parser_echo.add_argument('--input', '-i', help = 'Specify a file to read from, or leave blank for stdin.',\
+                             metavar = 'filename', type = argparse.FileType('r'), default = '-')
+
+parser_echo.add_argument('--parameters', '-p', dest = 'params', metavar="parameter_name", nargs='+', action = 'append',
+                             help = 'Specify parameters as name-value pairs [-p name value] to be passed to encoder and channel modules.')
+
 ######### END ARG PARSER #########
 
 def receiveData(channelName, params):
@@ -234,3 +247,25 @@ if args.subcommand == 'receive':
 
     output = decode(encoderNames, str(data[0]))
     sys.stdout.write(str(output))
+
+if args.subcommand == 'echo':
+    encoderNames = d.get('encoderNames')
+    params = d.get('params')
+    data = d.get('input').read()  # either a given file, or stdin
+
+    paramd = {}
+    if params:
+        for param in range(len(params)):
+            paramd[params[param][0]] = params[param][1]
+
+    # check the encoders all exist
+    for encoderName in encoderNames:
+        if encoderName not in encodingOptions:
+            print("ERROR: encoder " +
+                  encoderName +
+                  " does not exist. Exiting.")
+            sys.exit()
+
+    encoded = encode(encoderNames, data, paramd)
+    decoded = decode(encoderNames, encoded)
+    print(decoded)


### PR DESCRIPTION
Added a channel that writes out to a file, and reads in from a file.

Slightly overlaps with the `--input` parameter (in that it can read from a file) but the command line param can't write to a file - the channel can. Also allows more symmetry, since changing 'send' to 'receive' is enough to read from the file or vice versa, rather than specifying a completely different param.

I accidentally branched off of @ManickYoj's Echo command commit, but that was going to be merged anyway, so... I'll have to be more careful, derp.
