### PR TITLE
Channel fragments

### DIFF
--- a/channels/exampleChannel.py
+++ b/channels/exampleChannel.py
@@ -1,13 +1,15 @@
-# To create a new channel, create a new file named yourChannelName.py that has the following functions:
+'''
+To create a new channel, create a new file named yourChannelName.py that has the following functions:
+'''
 
 import time
 
 requiredParams = {
     'sending': {
-        # 'param_name', 'Brief description of the parameter."
+        # 'param_name': 'Brief description of the parameter.'
                },
     'receiving': {
-        # 'param_name', 'Brief description of the parameter."
+        # 'param_name': 'Brief description of the parameter.'
                  }
     }
 
@@ -18,4 +20,4 @@ def send(data, params):
     return
 
 def receive(params):
-    return "there would be some data here"
+    return ["there would be some data here", "and here as well"]

--- a/channels/file.py
+++ b/channels/file.py
@@ -1,0 +1,28 @@
+'''
+This channel writes the resultant data out to a file, or reads in from a file to receive.
+
+Useful for testing, and also out of band transfer.
+'''
+
+requiredParams = {
+    'sending': {
+        'filename': 'Name of the file to write data to.'
+               },
+    'receiving': {
+        'filename': 'Name of the file to read data from.'
+                 }
+    }
+
+def send(data, params):
+    print("Writing data to " + params['filename'] + "...")
+    with open(params['filename'] , 'w') as f:
+        f.write(data)
+    print("Done.")
+    return
+
+def receive(params):
+    print("Reading data from " + params['filename'] + "...")
+    with open(params['filename'], 'rb') as f:
+        data = f.read()
+    print("Done.")
+    return [data]

--- a/channels/twitter.py
+++ b/channels/twitter.py
@@ -3,6 +3,8 @@
 from twython import Twython, TwythonError
 import time
 
+description = "Posts data to Twitter as a series of 140 character Tweets."
+
 # TODO add optional params?
 requiredParams = {
     'sending': {

--- a/encoders/identity.py
+++ b/encoders/identity.py
@@ -1,0 +1,17 @@
+'''
+An encoder that does no encoding. Ironic, but also useful for testing channels.
+Or not encoding/decoding.
+'''
+
+requiredParams = {
+    'encode': {},
+    'decode': {}
+}
+
+
+def encode(data, params=None):
+    return data
+
+
+def decode(data, params=None):
+    return data

--- a/main.py
+++ b/main.py
@@ -62,6 +62,19 @@ parser_receive.add_argument('--encoder', '-e', dest = 'encoderNames', metavar="e
 parser_receive.add_argument('--parameters', '-p', dest = 'params', metavar="parameter_name", nargs='+', action = 'append',
                              help = 'Specify parameters as name-value pairs [-p name value] to be passed to encoder and channel modules.')
 
+
+# subparser for echoing data
+parser_echo = subparsers.add_parser('echo')
+
+parser_echo.add_argument('--encoder', '-e', dest = 'encoderNames', metavar="encoder_name", nargs='+', action = 'store',
+                             help = 'Choose one or more methods of encoding (done in order given).', required=True)
+
+parser_echo.add_argument('--input', '-i', help = 'Specify a file to read from, or leave blank for stdin.',\
+                             metavar = 'filename', type = argparse.FileType('r'), default = '-')
+
+parser_echo.add_argument('--parameters', '-p', dest = 'params', metavar="parameter_name", nargs='+', action = 'append',
+                             help = 'Specify parameters as name-value pairs [-p name value] to be passed to encoder and channel modules.')
+
 ######### END ARG PARSER #########
 
 def receiveData(channelName, params):
@@ -234,3 +247,25 @@ if args.subcommand == 'receive':
 
     output = decode(encoderNames, str(data[0]))
     sys.stdout.write(str(output))
+
+if args.subcommand == 'echo':
+    encoderNames = d.get('encoderNames')
+    params = d.get('params')
+    data = d.get('input').read()  # either a given file, or stdin
+
+    paramd = {}
+    if params:
+        for param in range(len(params)):
+            paramd[params[param][0]] = params[param][1]
+
+    # check the encoders all exist
+    for encoderName in encoderNames:
+        if encoderName not in encodingOptions:
+            print("ERROR: encoder " +
+                  encoderName +
+                  " does not exist. Exiting.")
+            sys.exit()
+
+    encoded = encode(encoderNames, data, paramd)
+    decoded = decode(encoderNames, encoded)
+    print(decoded)

--- a/main.py
+++ b/main.py
@@ -107,7 +107,7 @@ def sendData(channelName, data, params):
 
     # make sure we have all of the required parameters
     abort = False
-    for param,desc in chan.requiredParams['sending'].iteritems():
+    for param in chan.requiredParams['sending']:
         if not param in params:
             print("ERROR: Missing required parameter \'{}\' for channel \'{}\'.".format(param, channelName))
             abort = True # so that multiple problems can be found in one run
@@ -128,7 +128,7 @@ def encode(encoderNames, data, params):
 
         # make sure we have all of the required parameters
         abort = False
-        for param,desc in enc.requiredParams['encode'].iteritems():
+        for param in enc.requiredParams['encode']:
             if not param in params:
                 print("ERROR: Missing required parameter \'{}\' for encoder \'{}\'.".format(param, encoderName))
                 abort = True # so that multiple problems can be found in one run
@@ -245,6 +245,11 @@ if args.subcommand == 'receive':
     #    datar = str(data[datam])
     #    output = decode(encoderNames, datar)
 
+    if not isinstance(data, list):
+        raise TypeError('Data must be returned from channel receive method as an array.')
+        # the array is of individual 'packets' - i.e. metadata-wrapped bits of data
+        # this allows for timestamping messages, sending large messages as multiple
+        # fragments, etc.
     output = decode(encoderNames, str(data[0]))
     sys.stdout.write(str(output))
 

--- a/main.py
+++ b/main.py
@@ -272,5 +272,6 @@ if args.subcommand == 'echo':
             sys.exit()
 
     encoded = encode(encoderNames, data, paramd)
+    print("Encoded: " + encoded)
     decoded = decode(encoderNames, encoded)
-    print(decoded)
+    print("Decoded: " + decoded)


### PR DESCRIPTION
All channels now return data as an array of data 'packets.'

This helps move us toward packetizing all of our communications by wrapping them in metadata. This is important because some channels - Twitter, for example - can't send long messages in one block, and will need to be able to handle fragments.

An alternate option would be to have the channels handle concatenation themselves, but I like this way because it gives us more flexibility.

Case in point: sometime in the future, an important feature will be the "since" argument: only get data transmitted since a time (probably the last run - i.e. the last time you checked for anything new). Some channels will implement this by querying their API using a "since" field - Twitter's `since_id` is an example of this. However, other channels won't have that option, and will have to filter the results themselves - this gives both methods the flexibility to easily do so.
