### PR TITLE
Twitter > 140 Characters

### DIFF
--- a/channels/twitter.py
+++ b/channels/twitter.py
@@ -32,7 +32,11 @@ def send(data, params):
     SCREEN_NAME = params['name']
 
     twitter = Twython(APP_KEY, APP_SECRET, OAUTH_TOKEN, OAUTH_TOKEN_SECRET)
-    twitter.update_status(status= data)
+
+    tweets = [data[i:i+140] for i in range(0, len(data), 140)]
+    for tweet in tweets:
+      twitter.update_status(status=tweet)
+
     return
 
 def receive(params):


### PR DESCRIPTION
The Twitter channel now splits data with more than 140 characters into multiple tweets. 

Response to Issue #16.
