### PR TITLE
Fixed Echo Command & Misc Bugfixes

### DIFF
--- a/screep
+++ b/screep
@@ -65,7 +65,7 @@ parser_receive.add_argument('--channel', '-c', dest = 'channelName', metavar="ch
 parser_receive.add_argument('--encoder', '-e', dest = 'encoderNames', metavar="encoder_name", nargs='+', action = 'store',
                              help = 'Choose one or more methods of encoding (done in order given).', required=True)
 
-parser_receive.add_argument('--parameters', '-p', dest = 'params', metavar="parameter_name", type=json.loads,
+parser_receive.add_argument('--parameters', '-p', dest = 'params', metavar="parameter_name", type=json.loads, default={},
                              help = "Specify parameters in JSON as shown (including quotations): -p '{\"encoderOrChannel\": {\"key\": \"value\", ...}, ...}'")
 
 
@@ -79,7 +79,7 @@ parser_echo.add_argument('--encoder', '-e', dest = 'encoderNames', metavar="enco
 parser_echo.add_argument('--input', '-i', help = 'Specify a file to read from, or leave blank for stdin.',\
                              metavar = 'filename', type = argparse.FileType('r'), default = '-')
 
-parser_echo.add_argument('--parameters', '-p', dest = 'params', metavar="parameter_name", type=json.loads,
+parser_echo.add_argument('--parameters', '-p', dest = 'params', metavar="parameter_name", type=json.loads, default={},
                              help = "Specify parameters in JSON as shown (including quotations): -p '{\"encoderOrChannel\": {\"key\": \"value\", ...}, ...}'")
 
 # parse the args
@@ -232,7 +232,7 @@ def sendData(channelName, data, params):
         # send some stuff
         chan.send(packet, params)
 
-def encode(encoderNames, data, params):
+def encode(encoderName, data, params):
     # encode some data by passing it through the given encoder
     # encoder is ASSUMED GOOD
     moduleName = '.'.join(['encoders', encoderName])
@@ -285,6 +285,10 @@ def channels():
     return
 
 ############## RUN ##############
+
+args = parser.parse_args()
+d = vars(args)
+
 if args.subcommand == 'encoders':
     encoders()
 
@@ -320,7 +324,7 @@ if args.subcommand == 'send':
 
     encoded = data
     for encoderName in encoderNames:
-        encoded = encode(encoderNames, encoded, params[encoderName])
+        encoded = encode(encoderName, encoded, params[encoderName])
 
     sendData(channelName, encoded, params[channelName])
 
@@ -374,13 +378,23 @@ if args.subcommand == 'echo':
     params = d.get('params')
     data = d.get('input').read()  # either a given file, or stdin
 
-    # check the encoders all exist
     for encoderName in encoderNames:
+        # Check that all encoders exist
         if encoderName not in encodingOptions:
             error("encoder " + encoderName + " does not exist. Exiting.")
             sys.exit()
 
-    encoded = encode(encoderNames, data, params)
+        if encoderName not in params:
+            params[encoderName] = {}
+
+    encoded = data
+    for encoderName in encoderNames:
+        encoded = encode(encoderName, encoded, params[encoderName])
+
     output("Encoded: " + encoded)
-    decoded = decode(encoderNames, encoded, params)
+
+    decoded = encoded
+    for encoderName in reversed(encoderNames):
+        decoded = decode(encoderName, decoded, params[encoderName])
+
     output("Decoded: " + decoded)


### PR DESCRIPTION
Resolves #44 and some bugs without declared issues.
- Echo command had not been changed to run encode statements in loop, as send and receive do
- Fixed issue in encode: using encoderName when encoderNames was intended - caused scoping issue that did not throw error
- Fixed issue in 'send': passing encoderNames list into the encode encoderName variable
- Added default parameter of {} for params in receive and echo (it had previously only been applied to 'send' and caused other commands to fail when not called with a -p flag)
