### PR TITLE
JSON config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,25 @@ To just test out the base64 encoder:
 
 If you specify multiple encoders, the order is automatically reversed on decode so that you can specify them in the same order on both sides of the transmission and everything will work.
 
+Parameters
+==========
+
+Many channels and encoders require parameters to function. These parameters are submitted as JSON, keyed with the encoder or channel name. The value of these parameters is either one or several key-value pairs with the key specified by the encoder or channel.
+
+For example, the rsa encoder requires a public key filename, keyed as `publicKey` to send data, and a private key filename keyed as `privateKey` to receive it. Since the echo command both sends and receives, you can include the necessary parameters via the `-p` or `--parameters` flag followed by a JSON string (note the single quotes!) in your command as shown:
+
+`echo "super secret" | ./screep echo -e rsa -p '{"rsa": {"publicKey": "rsakey.pem.pub", "privateKey": "rsakey.pem"}}'`
+
+Alternatively, because it's a bore to enter all those parameters every time, they can be placed in a JSON file (with no need for the single quotes). In that case, simply use the filename as an argument.
+
+For example, if you have a file `config.json` which contains the JSON:
+`{"rsa": {"publicKey": "rsakey.pem.pub", "privateKey": "rsakey.pem"}}`
+
+Import the parameters from it via:
+`-p config.json` or `-p "config.json"`
+
+Leading to the much more succint command:
+`echo "super secret" | ./screep echo -e rsa -p config.json`
 
 Setup
 =====

--- a/screep
+++ b/screep
@@ -5,7 +5,7 @@ import pkgutil
 import sys
 import importlib
 import argparse
-import json
+import util
 
 import base94
 
@@ -52,9 +52,8 @@ parser_send.add_argument('--encoder', '-e', dest = 'encoderNames', metavar="enco
 parser_send.add_argument('--input', '-i', help = 'Specify a file to read from, or leave blank for stdin.',\
                              metavar = 'filename', type = argparse.FileType('r'), default = '-')
 
-parser_send.add_argument('--parameters', '-p', dest = 'params', metavar="parameter_name", type=json.loads, default={},
+parser_send.add_argument('--parameters', '-p', dest = 'params', metavar="parameter_name", type=util.jsonParse, default={},
                              help = "Specify parameters in JSON as shown (including quotations): -p '{\"encoderOrChannel\": {\"key\": \"value\", ...}, ...}'")
-
 
 # subparser for fetching data
 parser_receive = subparsers.add_parser('receive')
@@ -65,7 +64,7 @@ parser_receive.add_argument('--channel', '-c', dest = 'channelName', metavar="ch
 parser_receive.add_argument('--encoder', '-e', dest = 'encoderNames', metavar="encoder_name", nargs='+', action = 'store',
                              help = 'Choose one or more methods of encoding (done in order given).', required=True)
 
-parser_receive.add_argument('--parameters', '-p', dest = 'params', metavar="parameter_name", type=json.loads, default={},
+parser_receive.add_argument('--parameters', '-p', dest = 'params', metavar="parameter_name", type=util.jsonParse, default={},
                              help = "Specify parameters in JSON as shown (including quotations): -p '{\"encoderOrChannel\": {\"key\": \"value\", ...}, ...}'")
 
 
@@ -79,7 +78,7 @@ parser_echo.add_argument('--encoder', '-e', dest = 'encoderNames', metavar="enco
 parser_echo.add_argument('--input', '-i', help = 'Specify a file to read from, or leave blank for stdin.',\
                              metavar = 'filename', type = argparse.FileType('r'), default = '-')
 
-parser_echo.add_argument('--parameters', '-p', dest = 'params', metavar="parameter_name", type=json.loads, default={},
+parser_echo.add_argument('--parameters', '-p', dest = 'params', metavar="parameter_name", type=util.jsonParse, default={},
                              help = "Specify parameters in JSON as shown (including quotations): -p '{\"encoderOrChannel\": {\"key\": \"value\", ...}, ...}'")
 
 # parse the args

--- a/screep
+++ b/screep
@@ -65,7 +65,7 @@ parser_receive.add_argument('--channel', '-c', dest = 'channelName', metavar="ch
 parser_receive.add_argument('--encoder', '-e', dest = 'encoderNames', metavar="encoder_name", nargs='+', action = 'store',
                              help = 'Choose one or more methods of encoding (done in order given).', required=True)
 
-parser_receive.add_argument('--parameters', '-p', dest = 'params', metavar="parameter_name", type=json.loads,
+parser_receive.add_argument('--parameters', '-p', dest = 'params', metavar="parameter_name", type=json.loads, default={},
                              help = "Specify parameters in JSON as shown (including quotations): -p '{\"encoderOrChannel\": {\"key\": \"value\", ...}, ...}'")
 
 
@@ -79,7 +79,7 @@ parser_echo.add_argument('--encoder', '-e', dest = 'encoderNames', metavar="enco
 parser_echo.add_argument('--input', '-i', help = 'Specify a file to read from, or leave blank for stdin.',\
                              metavar = 'filename', type = argparse.FileType('r'), default = '-')
 
-parser_echo.add_argument('--parameters', '-p', dest = 'params', metavar="parameter_name", type=json.loads,
+parser_echo.add_argument('--parameters', '-p', dest = 'params', metavar="parameter_name", type=json.loads, default={},
                              help = "Specify parameters in JSON as shown (including quotations): -p '{\"encoderOrChannel\": {\"key\": \"value\", ...}, ...}'")
 
 # parse the args
@@ -232,7 +232,7 @@ def sendData(channelName, data, params):
         # send some stuff
         chan.send(packet, params)
 
-def encode(encoderNames, data, params):
+def encode(encoderName, data, params):
     # encode some data by passing it through the given encoder
     # encoder is ASSUMED GOOD
     moduleName = '.'.join(['encoders', encoderName])
@@ -285,6 +285,10 @@ def channels():
     return
 
 ############## RUN ##############
+
+args = parser.parse_args()
+d = vars(args)
+
 if args.subcommand == 'encoders':
     encoders()
 
@@ -320,7 +324,7 @@ if args.subcommand == 'send':
 
     encoded = data
     for encoderName in encoderNames:
-        encoded = encode(encoderNames, encoded, params[encoderName])
+        encoded = encode(encoderName, encoded, params[encoderName])
 
     sendData(channelName, encoded, params[channelName])
 
@@ -374,13 +378,23 @@ if args.subcommand == 'echo':
     params = d.get('params')
     data = d.get('input').read()  # either a given file, or stdin
 
-    # check the encoders all exist
     for encoderName in encoderNames:
+        # Check that all encoders exist
         if encoderName not in encodingOptions:
             error("encoder " + encoderName + " does not exist. Exiting.")
             sys.exit()
 
-    encoded = encode(encoderNames, data, params)
+        if encoderName not in params:
+            params[encoderName] = {}
+
+    encoded = data
+    for encoderName in encoderNames:
+        encoded = encode(encoderName, encoded, params[encoderName])
+
     output("Encoded: " + encoded)
-    decoded = decode(encoderNames, encoded, params)
+
+    decoded = encoded
+    for encoderName in reversed(encoderNames):
+        decoded = decode(encoderName, decoded, params[encoderName])
+
     output("Decoded: " + decoded)

--- a/util.py
+++ b/util.py
@@ -1,0 +1,40 @@
+"""
+Utility functions for screep.
+
+"""
+
+import json
+
+
+def jsonParse(strArg):
+    """
+    A utility to handle a string argument by either parsing it
+    directly as JSON or, if that fails, loading a JSON file at that
+    filepath.
+
+    :param strArg: Either a JSON string or filepath to a JSON file
+    :type strArg: str
+    :returns: The parsed JSON object
+    :rtype: dict
+    :raises: ValueError
+    """
+
+    # Try to parse strArg as a JSON string
+    try:
+        return json.loads(strArg)
+    except:
+        pass
+
+    # Try to use strArg as a filename and load the file
+    try:
+        with open(strArg) as configFile:
+            return json.load(configFile)
+    except:
+        pass
+
+    # Otherwise, raise an exception
+    exceptionMessage = ("""
+        Parameter argument was neither a valid JSON string,
+        nor a filepath to a valid JSON file.
+    """)
+    raise ValueError(exceptionMessage)


### PR DESCRIPTION
Resolves #6 by adding in the ability to read in JSON config files. Changes are documented in the README.

Note that this also includes the echo-fix commit in PR #47 because echo was non-functional without it, and thus the README examples would not work.

Recommendation is to merge this rather than #47 because it will avoid a merge conflict between them. Thus, this also resolves #44 .
